### PR TITLE
feat: redirect unauthenticated users to login

### DIFF
--- a/src/components/generic/withAuthServerSide.tsx
+++ b/src/components/generic/withAuthServerSide.tsx
@@ -1,0 +1,21 @@
+import {getServerAuthSession} from "~/server/auth";
+
+export function withAuthServerSideProps(){
+    return async (context: never) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        const session = await getServerAuthSession(context);
+
+        if (!session) {
+            return {
+                redirect: {
+                    destination: "/login",
+                    permanent: false,
+                },
+            };
+        }
+
+        return {
+            props: {},
+        };
+    }
+}

--- a/src/pages/account/index.tsx
+++ b/src/pages/account/index.tsx
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import {withAuthServerSideProps} from "~/components/generic/withAuthServerSide";
 
 export default function Home() {
     return (
@@ -14,3 +15,5 @@ export default function Home() {
         </>
     );
 }
+
+export const getServerSideProps = withAuthServerSideProps();

--- a/src/pages/calendar/index.tsx
+++ b/src/pages/calendar/index.tsx
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import {withAuthServerSideProps} from "~/components/generic/withAuthServerSide";
 
 export default function Home() {
     return (
@@ -14,3 +15,5 @@ export default function Home() {
         </>
     );
 }
+
+export const getServerSideProps = withAuthServerSideProps();

--- a/src/pages/definitions/index.tsx
+++ b/src/pages/definitions/index.tsx
@@ -6,6 +6,7 @@ import { Button, Input, Typography } from '@material-tailwind/react';
 import React, { useState } from 'react';
 
 import { Menu, MenuBody, MenuHandler } from '~/components/generic/menu';
+import {withAuthServerSideProps} from "~/components/generic/withAuthServerSide";
 
 interface CategorySetting {
     id: string | undefined;
@@ -175,3 +176,5 @@ export default function Home() {
         </>
     );
 }
+
+export const getServerSideProps = withAuthServerSideProps();

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -8,6 +8,7 @@ import {
 import SelectField from '~/components/forms/SelectField';
 import { useState } from 'react';
 import { api } from '~/utils/api';
+import {withAuthServerSideProps} from "~/components/generic/withAuthServerSide";
 
 const tzOptions = [
     { value: 'test', label: 'test' },
@@ -107,3 +108,5 @@ export default function Page() {
         </ThemeProvider>
     );
 }
+
+export const getServerSideProps = withAuthServerSideProps();

--- a/src/pages/sprint/index.tsx
+++ b/src/pages/sprint/index.tsx
@@ -15,6 +15,7 @@ import {
     getActivitiesFromDefinition,
 } from '~/data/activityDefinitions/virtualActivities';
 import { type ActivitySetting } from '~/components/activity/models';
+import {withAuthServerSideProps} from "~/components/generic/withAuthServerSide";
 
 export function getWeekStart(date: Date) {
     const today = date;
@@ -103,3 +104,5 @@ export default function Home() {
         </>
     );
 }
+
+export const getServerSideProps = withAuthServerSideProps();

--- a/src/pages/track/index.tsx
+++ b/src/pages/track/index.tsx
@@ -1,5 +1,6 @@
 import Head from 'next/head';
 import { TimelineView } from '~/components/timeline/timeline-view';
+import { withAuthServerSideProps } from "~/components/generic/withAuthServerSide";
 
 export default function Home() {
     const today = new Date();
@@ -33,3 +34,5 @@ export default function Home() {
         </>
     );
 }
+
+export const getServerSideProps = withAuthServerSideProps();

--- a/src/pages/zones/index.tsx
+++ b/src/pages/zones/index.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { api } from '~/utils/api';
 import { ZoneColumn } from '~/components/zone/zone-column';
 import { ZoneView } from '~/components/zone/zone-view';
+import {withAuthServerSideProps} from "~/components/generic/withAuthServerSide";
 
 export function getWeekStart(date: Date) {
     const today = date;
@@ -50,3 +51,5 @@ export default function Home() {
         </>
     );
 }
+
+export const getServerSideProps = withAuthServerSideProps();


### PR DESCRIPTION
Approach to redirect unauthenticated users to /login using Next.js' Server-Side Props 
https://github.com/vercel/next.js/discussions/10925

To make a page login-protected, append the following line: `export const getServerSideProps = withAuthServerSideProps();`